### PR TITLE
Verify that the color is valid before converting.

### DIFF
--- a/Revit2Gltf.Plugin/Commands/ExportToGltfCommand.cs
+++ b/Revit2Gltf.Plugin/Commands/ExportToGltfCommand.cs
@@ -144,11 +144,11 @@ namespace Revit2Gltf.Plugin.Commands
         {
             // view to export
             viewToExport = null;
-#if !REVIT2020
+//#if !REVIT2020
             viewToExport = docToExport.GetOrCreateDefault3DView();
-#else
-            viewToExport = AddinApplication.UIController.GetCurrentView(docToExport);
-#endif
+//#else
+//            viewToExport = AddinApplication.UIController.GetCurrentView(docToExport);
+//#endif
             if (viewToExport == null)
             {
                 return false;

--- a/Revit2Gltf/AssetPropertyDescriptor.cs
+++ b/Revit2Gltf/AssetPropertyDescriptor.cs
@@ -1,5 +1,5 @@
 ﻿using Autodesk.Revit.DB;
-#if REVIT2019
+#if REVIT2019 || REVIT2020
 using Autodesk.Revit.DB.Visual;
 #else
 using Autodesk.Revit.Utility;

--- a/Revit2Gltf/AssimpUtilities.cs
+++ b/Revit2Gltf/AssimpUtilities.cs
@@ -33,7 +33,7 @@ namespace Revit2Gltf
 
         public static Color4D ToColor4D(this RevitMaterial mat)
         {
-            var color = mat.Color;
+            var color = mat.Color.IsValid ? mat.Color : new Color(0, 0, 0);
             return new Color4D(color.Red * 1f / 255f, color.Green * 1f / 255f, color.Blue * 1f / 255f, mat.GetOpacity());
         }
 

--- a/Revit2Gltf/MaterialUtilities.cs
+++ b/Revit2Gltf/MaterialUtilities.cs
@@ -1,6 +1,6 @@
 ﻿using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
-#if REVIT2019
+#if REVIT2019 || REVIT2020
 using Autodesk.Revit.DB.Visual;
 #else
 using Autodesk.Revit.Utility;
@@ -123,8 +123,8 @@ namespace Revit2Gltf
                         // .UnifiedbitmapBitmap.  In earlier versions,
                         // you can still reference the string name 
                         // instead: "unifiedbitmap_Bitmap"
-                        AssetPropertyString path = connectedAsset[
-                          UnifiedBitmap.UnifiedbitmapBitmap]
+                        AssetPropertyString path = connectedAsset.FindByName(
+                          UnifiedBitmap.UnifiedbitmapBitmap)
                             as AssetPropertyString;
 #else
                         AssetPropertyString path =

--- a/Revit2Gltf/RenderAppearanceDescriptor.cs
+++ b/Revit2Gltf/RenderAppearanceDescriptor.cs
@@ -1,4 +1,4 @@
-﻿#if REVIT2019
+﻿#if REVIT2019 || REVIT2020
 using Autodesk.Revit.DB.Visual;
 #else
 using Autodesk.Revit.Utility;


### PR DESCRIPTION
This fixes an issue experienced converting a Revit 2019 model. Received an unhandled exception for an invalid or uninitialized color.